### PR TITLE
KDT3RDPROJ-33/React/메인페이지 가입할 수 없는 파티 ui처리

### DIFF
--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -41,7 +41,7 @@ const Main = () => {
   // 가입된 서비스 목록
   const [joinService, setJoinService] = useState([]);
   let jsId = 0;
-  let joinServiceId=0;
+  let joinServiceId = 0;
   // 가입 가능 여부 (이미 가입했을 경우 fasle)
   let joinPossible = true;
   let joinPartyPossible = true;
@@ -76,8 +76,7 @@ const Main = () => {
   // 최신 비디오 목록
   const [newVideoInfo, setNewVideoInfo] = useState(null);
   // 선택한 파티
-  const { selectParty, setSelectParty, service, setService } =
-    useContext(JoinPartyContext);
+  const { setSelectParty, setService } = useContext(JoinPartyContext);
 
   const navi = useNavigate();
   // 메인화면 로딩 시 페이지 맨 위로 끌어올리기
@@ -106,6 +105,7 @@ const Main = () => {
         setServiceList([]);
       });
   }, [loginId]);
+
   useEffect(() => {
     // 파티 목록 불러오기
     axios.get("/api/party/getPartyListForMain").then((resp) => {
@@ -127,8 +127,6 @@ const Main = () => {
       setPartyCount(formattedCount);
     });
 
-    
-
     const updateCurrentTime = () => {
       const now = new Date();
       const year = now.getFullYear();
@@ -149,10 +147,6 @@ const Main = () => {
     updateCurrentTime();
   }, []);
 
-  useEffect(()=>{
-    console.log(partyList)
-  },[partyList])
-
   // 파티 만들러 가기
   const handlePartyCreate = (e) => {
     const partyContentElement = e.currentTarget;
@@ -165,10 +159,7 @@ const Main = () => {
       setSelectService(partyContentElement.dataset.id);
       setModalIsOpen(true);
       setChked(false);
-      console.log("durl");
-      console.log(animate);
       onStop();
-      // setAnimate(false);
     }
   };
 
@@ -176,29 +167,31 @@ const Main = () => {
   const handleJoinModal = (e) => {
     const contentElement = e.currentTarget;
     const clickedElement = e.target;
-    console.log(contentElement);
-    console.log(clickedElement);
 
     if (
       clickedElement === contentElement ||
       contentElement.contains(clickedElement)
     ) {
-      if(clickedElement.className.includes("partyNotJoin")){
+      // 가입 할 수 없는 서비스의 파티에는 partyNotJoin이라는 클래스 명이 있음
+      if (clickedElement.className.includes("partyNotJoin")) {
         alert("이미 가입한 서비스의 파티입니다.\n추가 가입은 불가능합니다.");
-      }else{
+      } else {
+        // 가입할 수 있는 서비스의 파티라면 파티 참여 모달을 열어줌
         setJoinModalIsOpen(true);
         setSelectParty(
           partyList.find(
             (obj) => obj.id == contentElement.getAttribute("data-id")
           )
         );
-  
+
         const selectedObj = partyList.find(
           (obj) => obj.id == contentElement.getAttribute("data-id")
         );
-  
+
         const selectServiceId = selectedObj ? selectedObj.serviceId : null;
-        const serviceObj = serviceList.find((obj) => obj.id === selectServiceId);
+        const serviceObj = serviceList.find(
+          (obj) => obj.id === selectServiceId
+        );
         setService(serviceObj);
       }
     }
@@ -465,10 +458,14 @@ const Main = () => {
                           joinPartyPossible = false;
                           joinServiceId++;
                         } else joinPartyPossible = true;
-                        return(
+                        return (
                           <div
                             key={groupIndex * 4 + i}
-                            className={`${style.party} ${ !joinPartyPossible || loginId === "" ? style.partyNotJoin : ""}`}
+                            className={`${style.party} ${
+                              !joinPartyPossible || loginId === ""
+                                ? style.partyNotJoin
+                                : ""
+                            }`}
                             data-id={e.id}
                             onClick={handleJoinModal}
                           >
@@ -488,7 +485,8 @@ const Main = () => {
                                   <div>
                                     월
                                     {formatNumber(
-                                      Math.ceil(e.price / e.maxPeopleCount) + 1000
+                                      Math.ceil(e.price / e.maxPeopleCount) +
+                                        1000
                                     )}
                                     원
                                   </div>

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -41,8 +41,10 @@ const Main = () => {
   // 가입된 서비스 목록
   const [joinService, setJoinService] = useState([]);
   let jsId = 0;
+  let joinServiceId=0;
   // 가입 가능 여부 (이미 가입했을 경우 fasle)
   let joinPossible = true;
+  let joinPartyPossible = true;
   // 서비스 모달창 열림 / 닫힘
   const [modalIsOpen, setModalIsOpen] = useState(false);
   // 모달창을 띄울 서비스 종류
@@ -125,6 +127,8 @@ const Main = () => {
       setPartyCount(formattedCount);
     });
 
+    
+
     const updateCurrentTime = () => {
       const now = new Date();
       const year = now.getFullYear();
@@ -144,6 +148,10 @@ const Main = () => {
     // 페이지가 마운트될 때와 함께 첫 번째 시간 업데이트 실행
     updateCurrentTime();
   }, []);
+
+  useEffect(()=>{
+    console.log(partyList)
+  },[partyList])
 
   // 파티 만들러 가기
   const handlePartyCreate = (e) => {
@@ -175,20 +183,24 @@ const Main = () => {
       clickedElement === contentElement ||
       contentElement.contains(clickedElement)
     ) {
-      setJoinModalIsOpen(true);
-      setSelectParty(
-        partyList.find(
+      if(clickedElement.className.includes("partyNotJoin")){
+        alert("이미 가입한 서비스의 파티입니다.\n추가 가입은 불가능합니다.");
+      }else{
+        setJoinModalIsOpen(true);
+        setSelectParty(
+          partyList.find(
+            (obj) => obj.id == contentElement.getAttribute("data-id")
+          )
+        );
+  
+        const selectedObj = partyList.find(
           (obj) => obj.id == contentElement.getAttribute("data-id")
-        )
-      );
-
-      const selectedObj = partyList.find(
-        (obj) => obj.id == contentElement.getAttribute("data-id")
-      );
-
-      const selectServiceId = selectedObj ? selectedObj.serviceId : null;
-      const serviceObj = serviceList.find((obj) => obj.id === selectServiceId);
-      setService(serviceObj);
+        );
+  
+        const selectServiceId = selectedObj ? selectedObj.serviceId : null;
+        const serviceObj = serviceList.find((obj) => obj.id === selectServiceId);
+        setService(serviceObj);
+      }
     }
   };
 
@@ -448,47 +460,53 @@ const Main = () => {
                     {/* partyList를 4개씩 묶어서 매핑 */}
                     {partyList
                       .slice(groupIndex * 4, (groupIndex + 1) * 4)
-                      .map((e, i) => (
-                        <div
-                          key={groupIndex * 4 + i}
-                          className={style.party}
-                          data-id={e.id}
-                          onClick={handleJoinModal}
-                        >
-                          <div className={style.partyLeft}>
-                            <div className={style.partyTop}>
-                              <div className={style.partyStartDate}>
-                                {getStartDate(e.startDate)}
-                                <span className={style.monthCount}>
-                                  &nbsp;{e.monthCount}개월
-                                </span>
-                                파티
+                      .map((e, i) => {
+                        if (joinService.includes(e.serviceId)) {
+                          joinPartyPossible = false;
+                          joinServiceId++;
+                        } else joinPartyPossible = true;
+                        return(
+                          <div
+                            key={groupIndex * 4 + i}
+                            className={`${style.party} ${ !joinPartyPossible || loginId === "" ? style.partyNotJoin : ""}`}
+                            data-id={e.id}
+                            onClick={handleJoinModal}
+                          >
+                            <div className={style.partyLeft}>
+                              <div className={style.partyTop}>
+                                <div className={style.partyStartDate}>
+                                  {getStartDate(e.startDate)}
+                                  <span className={style.monthCount}>
+                                    &nbsp;{e.monthCount}개월
+                                  </span>
+                                  파티
+                                </div>
+                                <div className={style.partyPrice}>
+                                  <div className={style.wonIcon}>
+                                    <FontAwesomeIcon icon={faWonSign} />
+                                  </div>
+                                  <div>
+                                    월
+                                    {formatNumber(
+                                      Math.ceil(e.price / e.maxPeopleCount) + 1000
+                                    )}
+                                    원
+                                  </div>
+                                </div>
                               </div>
-                              <div className={style.partyPrice}>
-                                <div className={style.wonIcon}>
-                                  <FontAwesomeIcon icon={faWonSign} />
-                                </div>
-                                <div>
-                                  월
-                                  {formatNumber(
-                                    Math.ceil(e.price / e.maxPeopleCount) + 1000
-                                  )}
-                                  원
-                                </div>
+                              <div className={style.partyBottom}>
+                                ~ {getEndDate(e.startDate, e.monthCount)}까지
                               </div>
                             </div>
-                            <div className={style.partyBottom}>
-                              ~ {getEndDate(e.startDate, e.monthCount)}까지
+                            <div className={style.partyRight}>
+                              <img
+                                src={`/assets/serviceLogo/${e.englishName}.png`}
+                                alt={`${e.name} 로고 이미지`}
+                              />
                             </div>
                           </div>
-                          <div className={style.partyRight}>
-                            <img
-                              src={`/assets/serviceLogo/${e.englishName}.png`}
-                              alt={`${e.name} 로고 이미지`}
-                            />
-                          </div>
-                        </div>
-                      ))}
+                        );
+                      })}
                   </SwiperSlide>
                 )
               )

--- a/src/pages/Main/Main.module.css
+++ b/src/pages/Main/Main.module.css
@@ -299,6 +299,17 @@
 .yellowBack {
   background-color: #f9b81350 !important;
 }
+.partyNotJoin{
+  /* background-color: pink; */
+  background-color: #73757750;
+    opacity: 0.7;
+}
+.partyNotJoin:hover{
+  cursor: not-allowed;
+}
+.newVideoInfo>div>div:last-child{
+  text-align: end;
+}
 @media (max-width: 1030px) {
   .slideRight img {
     opacity: 0.4;

--- a/src/pages/Main/Main.module.css
+++ b/src/pages/Main/Main.module.css
@@ -6,9 +6,6 @@
   font-style: normal;
 }
 
-.mainDiv {
-  background-color: lightblue;
-}
 .rollingSlide,
 .newVideoInfo,
 .partyCardList {
@@ -16,15 +13,7 @@
   margin: auto;
   margin-bottom: 100px;
 }
-.newVideoInfo > div {
-  padding: 0;
-}
-.newVideoInfo p {
-  text-align: start !important;
-}
-.newVideoInfo button {
-  border-radius: 5px !important;
-}
+
 .rollingSlide {
   display: flex;
   flex-wrap: nowrap;
@@ -162,7 +151,7 @@
   color: #676d7c;
   margin-top: 20px;
 }
-
+/* 파티 참여하기 */
 .party {
   width: calc(50% - 20px);
   margin-bottom: 20px;
@@ -220,10 +209,10 @@
   font-size: 14px;
   margin-top: 10px;
 }
-
 .partyBtns {
   text-align: end;
 }
+/* 메인 박스 */
 .mainDiv {
   margin-bottom: 100px;
 }
@@ -297,18 +286,27 @@
   padding-left: 50px;
 }
 .yellowBack {
-  background-color: #f9b81350 !important;
+  background-color: #f9b81350;
 }
 .partyNotJoin{
-  /* background-color: pink; */
   background-color: #73757750;
     opacity: 0.7;
 }
 .partyNotJoin:hover{
   cursor: not-allowed;
 }
+/* 최신 비디오 */
 .newVideoInfo>div>div:last-child{
   text-align: end;
+}
+.newVideoInfo > div {
+  padding: 0;
+}
+.newVideoInfo p {
+  text-align: start !important;
+}
+.newVideoInfo button {
+  border-radius: 5px !important;
 }
 @media (max-width: 1030px) {
   .slideRight img {


### PR DESCRIPTION
1. Main.js
- 파티 참여를 위한 가입된 서비스 id를 담는 변수랑 가입 가능 여부를 담는 변수 추가
- JoinPartyContext에서 가져오는 요소 중 필요 없는거 제거
- 콘솔로그 제거함
- 파티에 가입할 때 가입할 수 있는 서비스의 파티인지 className으로 구분해서 파티참여 여부를 판단함
- 파티 목록을 그릴 때 해당 서비스의 파티에 가입할 수 있는지 판단해서 className에 partyNotJoin이라는 내용을 넣어줄 수 있도록 설정을 해줌
- 해당 css를 바꿈

-> 해당 내용은 로그인된 여부와 해당 서비스의 파티에 가입을 했는지 여부를 통해 파티 카드의 색깔을 바꿔주는데 로그인 하지 않은 사용자에 대해서도 컬러를 지금처럼 바꿔주는 것은 ui상 별로 좋아보이지 않아서 로그인 아이디가 없을때는 가입하지 않은 서비스의 파티와 똑같은 ui로 보이도록 설정하고 눌렀을 때 alert으로 로그인 먼저 해달라고 보내 버리도록 바꿀 예정입니다.